### PR TITLE
Report runtime status so a quiet gateway can be told from a dead one

### DIFF
--- a/src/dronecot/__init__.py
+++ b/src/dronecot/__init__.py
@@ -18,6 +18,17 @@
 
 """Drone Open Remote ID to TAK Gateway (with DJI Drone ID and UDP Remote ID support)."""
 
+from pathlib import Path
+
+# Read from the same VERSION file setup.cfg packages, so the version an operator
+# sees in the management UI cannot drift from the version of the installed .deb.
+__version__ = (
+    Path(__file__)
+    .resolve()
+    .parent.joinpath("VERSION")
+    .read_text(encoding="utf-8")
+    .strip()
+)
 
 from .constants import (  # NOQA
     DEFAULT_MQTT_TOPIC,

--- a/src/dronecot/classes.py
+++ b/src/dronecot/classes.py
@@ -42,6 +42,46 @@ import pytak
 import dronecot
 
 
+class _NoStatus:
+    """Stand-in for pytak.StatusWriter on a pytak too old to have one.
+
+    AryaOS boxes are updated as packages, so dronecot can land on a host whose
+    pytak predates StatusWriter (added in 7.4.0) -- 7.3.13 is still in the field.
+    A hard reference would raise AttributeError at import and take the gateway
+    down over its telemetry helper, which is exactly backwards: moving CoT is
+    the job, reporting on it is not.
+
+    Degrading here is safe because it is VISIBLE. With nothing writing
+    /run/dronecot/status.json, the Cockpit plugin reports "No status from this
+    gateway ... may be running a pytak too old to report status" rather than
+    rendering an empty decode feed as though the sky were empty.
+    """
+
+    def count(self, *args, **kwargs) -> None:
+        return None
+
+    def record(self, *args, **kwargs) -> None:
+        return None
+
+    def set(self, *args, **kwargs) -> None:
+        return None
+
+    def write(self, *args, **kwargs) -> bool:
+        return False
+
+
+# Resolved at import so a missing StatusWriter is a startup-time decision
+# rather than an AttributeError on the first Remote ID advertisement.
+_StatusWriter = getattr(pytak, "StatusWriter", None)
+
+
+def make_status(app_name: str, version: str):
+    """Return a status writer, or a no-op if this pytak has none."""
+    if _StatusWriter is None:
+        return _NoStatus()
+    return _StatusWriter(app_name, version=version)
+
+
 class SerialWorker(pytak.QueueWorker):
     """Queue Worker for MAVLink serial Open Drone ID."""
 
@@ -670,6 +710,19 @@ class RIDWorker(pytak.QueueWorker):
             else None
         )
 
+        # Runtime status for Cockpit. Systemd gives us /run/dronecot via
+        # RuntimeDirectory=, so this lands where the plugin looks for it.
+        #
+        # RIDWorker owns the status file rather than the capture workers because
+        # every RF source (Wi-Fi, BLE, BlueZ, serial MAVLink, MQTT, UDP) funnels
+        # through here. Instrumenting the capture workers instead would give N
+        # writers racing on one path, and each would see only its own slice.
+        self.status = make_status("dronecot", dronecot.__version__)
+
+    def _tracked(self) -> int:
+        """Number of transmitters the aggregator is currently holding."""
+        return len(self.aggregator) if self.aggregator is not None else 0
+
     async def handle_data(self, data: dict) -> None:
         """Handle Data from receiver: Render to CoT, put on TX queue.
 
@@ -680,39 +733,118 @@ class RIDWorker(pytak.QueueWorker):
         """
         self._logger.debug("Handling data: %s", data)
 
+        if not data:
+            # A decoder upstream produced nothing. Deliberately NOT counted as
+            # received: inflating rx with non-messages would make a receiver
+            # that hears only noise look like one hearing drones.
+            return
+
+        self.status.count("rx")
+
         if "status" in data and "position" not in data.get("topic", ""):
             self._logger.info("Processing sensor status data")
             event = dronecot.cot_to_xml(data, self.config, "sensor_status_to_cot")
+            if event:
+                self.status.count("emitted")
+                self.status.count("sensor_status")
+            else:
+                self.status.count("no_cot")
+            self.status.write()
             if event:
                 await self.put_queue(event)
             return
 
         if self.aggregator is not None:
             merged = self.aggregator.update(data)
+            self.status.set(tracked=self._tracked())
             if merged is None:
                 # Absorbed into a track that has no renderable position yet; it
                 # will contribute to the CoT rendered by a later advertisement.
+                # This is the COMMON case on BLE legacy, where a transmitter
+                # rotates BasicID -> Location -> System across advertisements,
+                # so it is counted rather than logged per-message.
                 self._logger.debug("Merged RID message, awaiting position")
+                self.status.count("merged_awaiting_position")
+                self.status.write()
                 return
             data = merged
 
         self._logger.info("Processing RID data")
         cot_funcs = ["rid_uas_to_cot_xml", "rid_op_to_cot_xml"]
+        events = []
         for func in cot_funcs:
             event = dronecot.cot_to_xml(data, self.config, func)
             if event:
-                await self.put_queue(event)
+                events.append(event)
+
+        # Record EVERY message that survives aggregation, not only the ones that
+        # produce a marker. A drone heard without a position still proves the
+        # receiver is working, and a feed that showed only plotted aircraft
+        # would sit empty on a perfectly healthy box -- which reads as a fault.
+        # The `placed` flag distinguishes the two without hiding either.
+        meta = data.get("data") or {}
+        self.status.record(
+            uas=data.get("BasicID") or data.get("BasicID_0"),
+            operator=data.get("OperatorID"),
+            mac=meta.get("MAC address"),
+            rssi=meta.get("RSSI"),
+            # "WiFi beacon", "WiFi NaN", "BLE", "BLE legacy (BlueZ)",
+            # "MAVLink ADSB_VEHICLE", or the configured SENSOR_PAYLOAD_TYPE.
+            source=meta.get("type"),
+            placed=bool(events),
+        )
+
+        if events:
+            self.status.count("emitted", len(events))
+        else:
+            self.status.count("no_cot")
+        self.status.write()
+
+        for event in events:
+            await self.put_queue(event)
 
     async def run(self, _=-1) -> None:
         """Run the main process loop."""
         self._logger.info("Running RIDWorker")
 
-        while True:
-            data = await self.net_queue.get()
-            if not data:
-                continue
+        # Write immediately, before any traffic arrives. A quiet sky is normal
+        # and can last hours; without this the management UI would report "no
+        # status from this gateway" -- indistinguishable from a gateway that
+        # failed to start -- for that entire time.
+        self.status.set(
+            tracked=self._tracked(),
+            # Scheme only. FEED_URL can carry MQTT credentials and status.json
+            # is world-readable on tmpfs.
+            feed=urlparse(str(self.config.get("FEED_URL", ""))).scheme or None,
+        )
+        self.status.write(force=True)
 
-            await self.handle_data(data)
+        # Heartbeat runs as its own task because the loop below blocks on
+        # net_queue.get(). Folding it into that await (via wait_for) would make
+        # every idle timeout look like an exception path; a separate task keeps
+        # the receive path unchanged.
+        heartbeat = asyncio.ensure_future(self._heartbeat())
+        try:
+            while True:
+                data = await self.net_queue.get()
+                if not data:
+                    continue
+
+                await self.handle_data(data)
+        finally:
+            heartbeat.cancel()
+
+    async def _heartbeat(self, interval: float = 5.0) -> None:
+        """Keep the status file fresh while no drones are in range.
+
+        The UI decides liveness from whether this file keeps changing, so an
+        idle-but-healthy gateway MUST keep writing; otherwise an empty sky would
+        be reported as a wedged service.
+        """
+        while True:
+            await asyncio.sleep(interval)
+            self.status.set(tracked=self._tracked())
+            self.status.write(force=True)
 
 
 class RXMockWorker(pytak.RXWorker):

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""Tests for the runtime status surface RIDWorker writes for Cockpit.
+
+These drive the coroutine with ``asyncio.run()`` rather than declaring bare
+``async def`` tests. That is not a style choice: pytest-asyncio is not installed
+in the build/CI environment for this package, and pytest SKIPS bare async tests
+while still reporting the run as passed -- i.e. tests that cannot fail. Calling
+asyncio.run() explicitly keeps them real regardless of plugins.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import struct
+
+import pytest
+
+import pytak
+
+from dronecot import classes, rid_normalize, rid_track
+
+
+ODID_MESSAGE_SIZE = 25
+PROTO_VERSION = 2
+
+TEST_MAC = "AA:BB:CC:DD:EE:01"
+TEST_SERIAL = "1596F3AD8E2B4C5D6E7F"
+
+needs_statuswriter = pytest.mark.skipif(
+    not hasattr(pytak, "StatusWriter"),
+    reason="installed pytak has no StatusWriter (pre-7.4.0)",
+)
+
+
+def _basic_id_message(serial: str = TEST_SERIAL) -> bytes:
+    """A single ODID BasicID message (type 0): serial, no position."""
+    msg = bytearray(ODID_MESSAGE_SIZE)
+    msg[0] = (0 << 4) | PROTO_VERSION
+    msg[1] = (1 << 4) | 2
+    msg[2:22] = serial.encode("ascii").ljust(20, b"\x00")
+    return bytes(msg)
+
+
+def _location_message(lat: float = 37.76, lon: float = -122.4) -> bytes:
+    """A single ODID Location message (type 1): position, no serial."""
+    msg = bytearray(ODID_MESSAGE_SIZE)
+    msg[0] = (1 << 4) | PROTO_VERSION
+    msg[1] = 0x20  # Status=2 (Airborne)
+    msg[2] = 90
+    msg[3] = 10
+    msg[5:9] = struct.pack("i", int(lat * 1e7))
+    msg[9:13] = struct.pack("i", int(lon * 1e7))
+    msg[13:15] = struct.pack("H", 2000 + 200)
+    msg[15:17] = struct.pack("H", 2000 + 200)
+    msg[17:19] = struct.pack("H", 2000 + 100)
+    return bytes(msg)
+
+
+def _rid(msg: bytes, mac: str = TEST_MAC, rssi: int = -71) -> dict:
+    """Normalize one ODID message the way a BLE capture worker would."""
+    return rid_normalize.bytes_to_rid_dict(
+        msg, {"MAC address": mac, "RSSI": rssi, "type": "BLE legacy (BlueZ)"}
+    )
+
+
+async def _noop_put(event):
+    return None
+
+
+@needs_statuswriter
+class TestStatusSurface:
+    """What the Cockpit plugin reads out of /run/dronecot/status.json.
+
+    RIDWorker already made these decisions -- merge, render, drop -- they just
+    went nowhere an operator could see. The risk with a status surface is that
+    it reports the shape of the code rather than what actually happened, so
+    these assert against real ODID advertisements pushed through the worker.
+    """
+
+    def _worker(self, tmp_path, ttl=120.0, id_grace=5.0):
+        worker = classes.RIDWorker.__new__(classes.RIDWorker)
+        worker.config = {}
+        worker.net_queue = None
+        worker.aggregator = rid_track.ODIDAggregator(ttl=ttl, id_grace=id_grace)
+        worker._logger = logging.getLogger("test")
+        worker.status = pytak.StatusWriter(
+            "dronecot-test", path=str(tmp_path / "status.json")
+        )
+        worker.put_queue = _noop_put
+        return worker
+
+    def _handle(self, worker, data):
+        asyncio.run(worker.handle_data(data))
+
+    def _doc(self, worker):
+        with open(worker.status.path) as handle:
+            return json.load(handle)
+
+    def test_id_only_fragment_is_counted_not_silently_dropped(self, tmp_path):
+        """A BasicID advertisement carries no position, so it renders no CoT.
+
+        On BLE legacy this is the majority of traffic. Before this surface it
+        vanished at debug level, so a receiver hearing a drone loud and clear
+        looked identical to one hearing nothing at all.
+        """
+        worker = self._worker(tmp_path)
+        self._handle(worker, _rid(_basic_id_message()))
+
+        doc = self._doc(worker)
+        assert doc["counters"]["rx"] == 1
+        assert doc["counters"]["merged_awaiting_position"] == 1
+        assert "emitted" not in doc["counters"]
+        # Nothing renderable yet, so nothing claims to be a contact.
+        assert doc["recent"] == []
+        assert doc["tracked"] == 1
+
+    def test_merged_track_emits_and_appears_in_the_feed(self, tmp_path):
+        """Serial from one advertisement, position from the next -> one contact."""
+        worker = self._worker(tmp_path)
+        self._handle(worker, _rid(_basic_id_message()))
+        self._handle(worker, _rid(_location_message()))
+
+        # Writes are rate-limited to 1/sec, so two messages in the same second
+        # leave the file holding the first one's figures. That is by design --
+        # a gateway taking hundreds of advertisements a second must not spend
+        # its time serialising JSON -- and run()'s 5s heartbeat is what
+        # reconciles it. Forcing here stands in for that heartbeat.
+        worker.status.write(force=True)
+
+        doc = self._doc(worker)
+        assert doc["counters"]["rx"] == 2
+        assert doc["counters"]["emitted"] >= 1
+        entry = doc["recent"][-1]
+        assert entry["uas"] == TEST_SERIAL
+        assert entry["placed"] is True
+        assert entry["rssi"] == -71
+        assert entry["source"] == "BLE legacy (BlueZ)"
+        assert entry["mac"] == TEST_MAC
+
+    def test_two_transmitters_are_tracked_separately(self, tmp_path):
+        """tracked is the aggregator's real size, not a message count."""
+        worker = self._worker(tmp_path)
+        self._handle(worker, _rid(_basic_id_message(), mac="AA:BB:CC:DD:EE:01"))
+        self._handle(worker, _rid(_basic_id_message("OTHER"), mac="AA:BB:CC:DD:EE:02"))
+        worker.status.write(force=True)
+
+        assert self._doc(worker)["tracked"] == 2
+
+    def test_empty_payload_is_not_counted_as_received(self, tmp_path):
+        """A decoder that produced nothing is not a drone.
+
+        Counting it would make a receiver hearing only noise indistinguishable
+        from one hearing traffic, which is the exact confusion this file exists
+        to remove.
+        """
+        worker = self._worker(tmp_path)
+        self._handle(worker, {})
+        assert not os.path.exists(worker.status.path)
+
+    def test_unrenderable_record_is_counted_as_no_cot(self, tmp_path):
+        """Aggregation off: a position-less record reaches the renderer and fails.
+
+        With RID_TRACK_TTL=0 there is no aggregator, so the fragment goes
+        straight to cot_to_xml, which cannot place it. That is a distinct
+        outcome from "held for merging" and gets a distinct counter.
+        """
+        worker = self._worker(tmp_path)
+        worker.aggregator = None
+        self._handle(worker, _rid(_basic_id_message()))
+
+        doc = self._doc(worker)
+        assert doc["counters"]["rx"] == 1
+        assert doc["counters"]["no_cot"] == 1
+        assert "merged_awaiting_position" not in doc["counters"]
+        # Still shown in the feed: it WAS decoded, it just could not be placed.
+        assert doc["recent"][-1]["placed"] is False
+        assert doc["recent"][-1]["uas"] == TEST_SERIAL
+
+
+@needs_statuswriter
+class TestStatusHeartbeat:
+    """An idle-but-healthy gateway must keep writing."""
+
+    def test_heartbeat_refreshes_the_file(self, tmp_path):
+        worker = classes.RIDWorker.__new__(classes.RIDWorker)
+        worker.config = {}
+        worker.aggregator = rid_track.ODIDAggregator()
+        worker._logger = logging.getLogger("test")
+        worker.status = pytak.StatusWriter(
+            "dronecot-test", path=str(tmp_path / "status.json")
+        )
+
+        async def _drive():
+            task = asyncio.ensure_future(worker._heartbeat(interval=0.01))
+            await asyncio.sleep(0.05)
+            task.cancel()
+
+        asyncio.run(_drive())
+
+        with open(worker.status.path) as handle:
+            doc = json.load(handle)
+        # No traffic at all, yet the file exists and reports a wall clock the
+        # UI can use to tell "quiet" from "stopped".
+        assert doc["counters"] == {}
+        assert doc["wall_t"] > 0
+        assert doc["tracked"] == 0
+
+
+class TestStatusDegradesVisibly:
+    """A pytak without StatusWriter must not take the gateway down.
+
+    Fleet boxes run pytak 7.3.13, which has no StatusWriter at all.
+    """
+
+    def test_no_op_status_when_pytak_is_too_old(self, monkeypatch):
+        monkeypatch.setattr(classes, "_StatusWriter", None)
+        status = classes.make_status("dronecot", "0.1.0")
+
+        # Every call RIDWorker makes must be safe on the stand-in.
+        status.count("rx")
+        status.count("emitted", 2)
+        status.record(uas="X", placed=True)
+        status.set(tracked=1)
+        assert status.write() is False
+        assert status.write(force=True) is False
+
+    def test_worker_still_handles_data_with_no_statuswriter(self, monkeypatch):
+        """The whole point: no StatusWriter must not break the data path.
+
+        The renderer is stubbed so this test asserts what it claims to --
+        that RIDWorker still aggregates and still enqueues -- rather than
+        incidentally re-testing dronecot's CoT rendering against whatever
+        pytak happens to be installed.
+        """
+        monkeypatch.setattr(classes, "_StatusWriter", None)
+        monkeypatch.setattr(
+            classes.dronecot, "cot_to_xml", lambda data, config, func: b"<event/>"
+        )
+
+        worker = classes.RIDWorker.__new__(classes.RIDWorker)
+        worker.config = {}
+        worker.aggregator = rid_track.ODIDAggregator()
+        worker._logger = logging.getLogger("test")
+        worker.status = classes.make_status("dronecot", "0.1.0")
+
+        emitted = []
+
+        async def _put(event):
+            emitted.append(event)
+
+        worker.put_queue = _put
+
+        asyncio.run(worker.handle_data(_rid(_basic_id_message())))
+        # Held for merging: no position yet, so nothing to send.
+        assert emitted == []
+
+        asyncio.run(worker.handle_data(_rid(_location_message())))
+
+        assert isinstance(worker.status, classes._NoStatus)
+        assert emitted, "CoT must still be produced when status is unavailable"
+
+    def test_real_writer_used_when_available(self):
+        if classes._StatusWriter is None:
+            pytest.skip("installed pytak has no StatusWriter")
+        assert not isinstance(classes.make_status("x", "0"), classes._NoStatus)


### PR DESCRIPTION
## Why

A dronecot box that is working and one that is wedged look identical from outside: both are `active (running)` to systemd, both hold their radio open, and both produce no CoT when nothing is flying. The only way to tell them apart was to read the journal — and even that showed nothing useful, because the majority of BLE legacy traffic is fragments that get merged and logged at debug level. A receiver hearing a DroneBeacon loud and clear left the same trace as one hearing static.

## What

`RIDWorker` now writes pytak's status surface to `/run/dronecot/status.json`.

Counters:

| counter | meaning |
| --- | --- |
| `rx` | inbound Remote ID records |
| `emitted` | CoT events put on the TX queue |
| `merged_awaiting_position` | fragments absorbed pending a position — the **common** case on BLE legacy, not an error |
| `no_cot` | decoded but not renderable |
| `sensor_status` | MQTT sensor-status events |
| `tracked` (field) | live size of the ODID aggregator |

Plus a `recent` decode feed carrying UAS serial, operator ID, MAC, RSSI and source (`WiFi beacon`, `WiFi NaN`, `BLE`, `BLE legacy (BlueZ)`, `MAVLink ADSB_VEHICLE`, …) with a `placed` flag.

Decodes are recorded whether or not they render a marker. A feed showing only plotted aircraft sits empty on a perfectly healthy receiver, which an operator reads as a fault; `placed` keeps "heard but not placeable" distinct from "not heard".

### Design notes

- **`RIDWorker` owns the file, not the capture workers.** Every RF source (Wi-Fi, BLE, BlueZ, serial MAVLink, MQTT, UDP) funnels through it. Instrumenting the capture workers instead would give N writers racing on one path, each seeing only its own slice.
- **Startup write with `force=True`** before any traffic. Without it the UI reports "no status", which is indistinguishable from failed-to-start.
- **5 s heartbeat task.** Without it an idle sky reads as a wedged service. It is a separate task because the receive loop blocks on `net_queue.get()`; folding it into that await would make every idle timeout look like an exception path.
- **`FEED_URL` is reported by scheme only** — it can carry MQTT credentials, and `status.json` is world-readable on tmpfs.

### StatusWriter is acquired defensively, and that is required

`_StatusWriter = getattr(pytak, "StatusWriter", None)` at import, with a `_NoStatus` no-op stand-in. Fleet boxes are updated as packages and are still running **pytak 7.3.13, which has no StatusWriter at all**. A hard reference would raise `AttributeError` at import and take the gateway down over its telemetry helper — exactly backwards, since moving CoT is the job and reporting on it is not.

The degradation is *visible*: with no status file the Cockpit plugin says so, rather than rendering an empty feed as though the sky were clear.

Also adds `dronecot.__version__`, read from the same `VERSION` file `setup.cfg` packages, so the version shown in the UI cannot drift from the installed `.deb`.

`debian/dronecot.service` already sets `RuntimeDirectory=dronecot`, so `/run/dronecot` exists; no packaging change needed.

## Tests

New `tests/test_status.py` (9 tests). They drive the coroutines with `asyncio.run()` rather than bare `async def`: **pytest-asyncio is not installed for this package, and pytest SKIPS bare async tests while still reporting the run as passed** — tests that cannot fail. They are gated on `hasattr(pytak, "StatusWriter")` and assert real effects: counter values, `recent` contents, that an empty payload is *not* counted as received, and that the data path still works with `_StatusWriter` monkeypatched to `None`.

Verified by mutation: stubbing out the `rx` and `merged_awaiting_position` counters fails 3 of them.

| environment | before | after |
| --- | --- | --- |
| pytak 7.3.11 (no StatusWriter) | 10 failed, 62 passed, 1 skipped | 10 failed, 64 passed, 8 skipped |
| pytak `main` (StatusWriter) | 72 passed, 1 skipped | 81 passed, 1 skipped |

The 10 failures are pre-existing and environmental: the local system pytak is 7.3.11, below this package's declared `pytak >= 7.3.12` minimum, so `pytak.cot_event` is missing. Unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM